### PR TITLE
Don't list all of the bans

### DIFF
--- a/inc/classes/ban.php
+++ b/inc/classes/ban.php
@@ -325,7 +325,7 @@ class ban {
     }
     $where = null;
     if($active){
-      $where = "AND tbl_ban.expiration_time > NOW() OR tbl_ban.unbanned IS NULL";
+      $where = "AND (tbl_ban.expiration_time > NOW() OR tbl_ban.unbanned IS NULL)";
     }
     $db->query("SELECT *,
       TIMESTAMPDIFF(MINUTE, tbl_ban.bantime, tbl_ban.expiration_time) AS minutes


### PR DESCRIPTION
There was a bug in this function which would list all of the bans.

```
SELECT 
    *,
    TIMESTAMPDIFF(MINUTE,
        ban.bantime,
        ban.expiration_time) AS minutes
FROM
    ban
WHERE
    ckey = 'Jambread'
        AND ban.expiration_time > NOW()
        OR ban.unbanned IS NULL
ORDER BY bantime DESC
```

verus

```
SELECT 
    *,
    TIMESTAMPDIFF(MINUTE,
        ban.bantime,
        ban.expiration_time) AS minutes
FROM
    ban
WHERE
    ckey = 'Jambread'
        AND (ban.expiration_time > NOW()
        OR ban.unbanned IS NULL)
ORDER BY bantime DESC
```

Loading 16k bans is not good for PHP.